### PR TITLE
Prevent entire empty card stack from converting to same card

### DIFF
--- a/java/com/is/mtc/card/CardItem.java
+++ b/java/com/is/mtc/card/CardItem.java
@@ -1,5 +1,7 @@
 package com.is.mtc.card;
 
+import java.util.List;
+
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.Reference;
 import com.is.mtc.data_manager.CardStructure;
@@ -8,6 +10,8 @@ import com.is.mtc.handler.GuiHandler;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
 import com.is.mtc.root.Tools;
+
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -15,18 +19,16 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
-import java.util.List;
-
 public class CardItem extends Item {
-
-	private static final String prefix = "item_card_";
+	
+	private static final String PREFIX = "item_card_";
 	private static final int MAX_DESC_LENGTH = 42;
 
 	private int rarity;
 
 	public CardItem(int r) {
-		setUnlocalizedName(prefix + Rarity.toString(r).toLowerCase());
-		setTextureName(Reference.MODID + ":" + prefix + Rarity.toString(r).toLowerCase());
+		setUnlocalizedName(PREFIX + Rarity.toString(r).toLowerCase());
+		setTextureName(Reference.MODID + ":" + PREFIX + Rarity.toString(r).toLowerCase());
 		setCreativeTab(MineTradingCards.MODTAB);
 
 		rarity = r;
@@ -35,17 +37,26 @@ public class CardItem extends Item {
 	public int getCardRarity() {
 		return rarity;
 	}
-
+	
+	private ItemStack applyCDWDtoStack(ItemStack stack, CardStructure cStruct) {
+		stack.stackTagCompound.setString("cdwd", cStruct.getCDWD());
+		if (cStruct.getAssetPath().size() > 0) {
+			stack.stackTagCompound.setInteger("assetnumber", Tools.randInt(0, cStruct.getAssetPath().size()));
+		}
+		return stack;
+	}
+	
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
 		String cdwd = Tools.hasCDWD(stack) ? stack.stackTagCompound.getString("cdwd") : null;
 		CardStructure cStruct = cdwd != null ? Databank.getCardByCDWD(cdwd) : null;
 
 		if (cdwd != null) {
-			if (cStruct == null) // Card not registered ? Display cdwd
+			if (cStruct == null) { // Card not registered ? Display cdwd
 				return cdwd;
-			else
+			} else {
 				return cStruct.getName();
+			}
 		} else
 			return super.getItemStackDisplayName(stack);
 	}
@@ -57,29 +68,47 @@ public class CardItem extends Item {
 			if (Tools.hasCDWD(stack)) {
 				player.openGui(MineTradingCards.INSTANCE, GuiHandler.GUI_CARD, world, (int) player.posX, (int) player.posY, (int) player.posZ);
 			}
-
 			return stack;
 		}
 
-		if (!stack.hasTagCompound())
+		if (!stack.hasTagCompound()) {
 			stack.stackTagCompound = new NBTTagCompound();
-
+		}
+		
 		if (!Tools.hasCDWD(stack)) {
 			CardStructure cStruct = Databank.generateACard(rarity);
-
+			
 			if (cStruct != null) {
-				stack.stackTagCompound.setString("cdwd", cStruct.getCDWD());
-				if (cStruct.getAssetPath().size() > 0)
-					stack.stackTagCompound.setInteger("assetnumber", Tools.randInt(0, cStruct.getAssetPath().size()));
+				if (stack.stackSize!=1) { // Generate a single card from the stack and drop it into inventory
+					ItemStack popoffStack = stack.copy();
+					if (!popoffStack.hasTagCompound()) {
+						popoffStack.stackTagCompound = new NBTTagCompound();
+					}
+					popoffStack.stackSize=1;
+					popoffStack = applyCDWDtoStack(popoffStack, cStruct);
+					
+					EntityItem dropped_card = player.entityDropItem(popoffStack, 1);
+					dropped_card.delayBeforeCanPickup = 0;
+					
+					if (!player.capabilities.isCreativeMode) {
+						stack.stackSize--;
+					}
+				}
+				else { // Add data to the singleton "empty" card 
+					stack = applyCDWDtoStack(stack, cStruct);
+				}
+				
 			} else
 				Logs.errLog("Unable to generate a card of this rarity: " + Rarity.toString(rarity));
 		}
 
 		if (!stack.stackTagCompound.hasKey("assetnumber")) {
 			CardStructure cStruct = Databank.getCardByCDWD(stack.stackTagCompound.getString("cdwd"));
-			if (cStruct != null)
-				if (cStruct.getAssetPath().size() > 0)
+			if (cStruct != null) {
+				if (cStruct.getAssetPath().size() > 0) {
 					stack.stackTagCompound.setInteger("assetnumber", Tools.randInt(0, cStruct.getAssetPath().size()));
+				}
+			}
 		}
 
 		return stack;
@@ -91,8 +120,9 @@ public class CardItem extends Item {
 		CardStructure cStruct;
 		NBTTagCompound nbt;
 
-		if (!stack.hasTagCompound() || !Tools.hasCDWD(stack))
+		if (!stack.hasTagCompound() || !Tools.hasCDWD(stack)) {
 			return;
+		}
 
 		nbt = stack.stackTagCompound;
 		cStruct = Databank.getCardByCDWD(nbt.getString("cdwd"));
@@ -106,8 +136,9 @@ public class CardItem extends Item {
 		infos.add("");
 		infos.add("Edition: " + Rarity.toColor(rarity) + Databank.getEditionWithId(cStruct.getEdition()).getName());
 
-		if (!cStruct.getCategory().isEmpty())
+		if (!cStruct.getCategory().isEmpty()) {
 			infos.add("Category: " + EnumChatFormatting.WHITE + cStruct.getCategory());
+		}
 
 		if (!cStruct.getDescription().isEmpty()) {
 			String[] words = cStruct.getDescription().split(" ");
@@ -122,8 +153,9 @@ public class CardItem extends Item {
 					line = "";
 				}
 			}
-			if (!line.isEmpty())
+			if (!line.isEmpty()) {
 				infos.add(line);
+			}
 		}
 
 		infos.add("");


### PR DESCRIPTION
Previously, if you right-clicked an ItemStack of blank cards, applyCDWDtoStack would apply to the entire stack, making them all the same (randomized) card.

With this PR, the stack will shed a single card to become the newly-randomized card. The rest of the stack will remain blank.

In addition, I did a little style cleanup.