### PR TITLE
Add config option for card recipes

### DIFF
--- a/java/com/is/mtc/Reference.java
+++ b/java/com/is/mtc/Reference.java
@@ -2,6 +2,7 @@ package com.is.mtc;
 
 public class Reference {
 	public static final String MODID = "is_mtc";
-	public static final String VERSION = "2.3.0";
+	public static final String MOD_VERSION = "2.3.0";
+	public static final String CONFIG_VERSION = "1.1";
 	public static final String NAME = "Mine Trading Cards";
 }

--- a/java/com/is/mtc/binder/BinderItem.java
+++ b/java/com/is/mtc/binder/BinderItem.java
@@ -1,16 +1,17 @@
 package com.is.mtc.binder;
 
+import java.util.List;
+
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.Reference;
 import com.is.mtc.handler.GuiHandler;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 public class BinderItem extends Item {
 

--- a/java/com/is/mtc/binder/BinderItemContainer.java
+++ b/java/com/is/mtc/binder/BinderItemContainer.java
@@ -2,6 +2,7 @@ package com.is.mtc.binder;
 
 import com.is.mtc.root.CardSlot;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;

--- a/java/com/is/mtc/binder/BinderItemInterfaceContainer.java
+++ b/java/com/is/mtc/binder/BinderItemInterfaceContainer.java
@@ -1,11 +1,21 @@
 package com.is.mtc.binder;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.util.vector.Vector2f;
+
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.Reference;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.packet.MTCMessage;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
@@ -22,14 +32,6 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.input.Keyboard;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-import org.lwjgl.util.vector.Vector2f;
-
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
 
 public class BinderItemInterfaceContainer extends GuiScreen {
 	protected static final ResourceLocation field_147001_a = new ResourceLocation("textures/gui/container/inventory.png");

--- a/java/com/is/mtc/binder/BinderItemInventory.java
+++ b/java/com/is/mtc/binder/BinderItemInventory.java
@@ -1,14 +1,15 @@
 package com.is.mtc.binder;
 
+import java.util.Arrays;
+
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.Constants;
-
-import java.util.Arrays;
 
 public class BinderItemInventory implements IInventory {
 

--- a/java/com/is/mtc/card/CardItemInterface.java
+++ b/java/com/is/mtc/card/CardItemInterface.java
@@ -2,6 +2,7 @@ package com.is.mtc.card;
 
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
+
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;

--- a/java/com/is/mtc/data_manager/CDFCardStructure.java
+++ b/java/com/is/mtc/data_manager/CDFCardStructure.java
@@ -1,9 +1,9 @@
 package com.is.mtc.data_manager;
 
-import com.is.mtc.root.Tools;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.is.mtc.root.Tools;
 
 public class CDFCardStructure {
 

--- a/java/com/is/mtc/data_manager/CardStructure.java
+++ b/java/com/is/mtc/data_manager/CardStructure.java
@@ -1,21 +1,23 @@
 package com.is.mtc.data_manager;
 
-import com.google.gson.JsonElement;
-import com.is.mtc.MineTradingCards;
-import com.is.mtc.root.Logs;
-import com.is.mtc.root.Rarity;
-import com.is.mtc.root.Tools;
-import net.minecraft.client.renderer.texture.DynamicTexture;
-import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.util.ResourceLocation;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import javax.imageio.ImageIO;
+
+import com.google.gson.JsonElement;
+import com.is.mtc.MineTradingCards;
+import com.is.mtc.root.Logs;
+import com.is.mtc.root.Rarity;
+import com.is.mtc.root.Tools;
+
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.util.ResourceLocation;
 
 /*
  * Card is identified by id and edition. Same id can be in two different editions

--- a/java/com/is/mtc/data_manager/CustomPackStructure.java
+++ b/java/com/is/mtc/data_manager/CustomPackStructure.java
@@ -1,10 +1,10 @@
 package com.is.mtc.data_manager;
 
-import com.google.gson.JsonElement;
-import com.is.mtc.root.Tools;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.is.mtc.root.Tools;
 
 public class CustomPackStructure {
 	private String name, id;

--- a/java/com/is/mtc/data_manager/DataLoader.java
+++ b/java/com/is/mtc/data_manager/DataLoader.java
@@ -1,17 +1,27 @@
 package com.is.mtc.data_manager;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.commons.io.filefilter.RegexFileFilter;
-
-import java.io.*;
-import java.util.*;
 
 
 public class DataLoader {

--- a/java/com/is/mtc/data_manager/Databank.java
+++ b/java/com/is/mtc/data_manager/Databank.java
@@ -1,11 +1,11 @@
 package com.is.mtc.data_manager;
 
-import com.is.mtc.root.Logs;
-import com.is.mtc.root.Rarity;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
+
+import com.is.mtc.root.Logs;
+import com.is.mtc.root.Rarity;
 
 public class Databank {
 

--- a/java/com/is/mtc/displayer/DisplayerBlock.java
+++ b/java/com/is/mtc/displayer/DisplayerBlock.java
@@ -4,6 +4,7 @@ import com.is.mtc.MineTradingCards;
 import com.is.mtc.Reference;
 import com.is.mtc.handler.GuiHandler;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;

--- a/java/com/is/mtc/displayer/DisplayerBlockContainer.java
+++ b/java/com/is/mtc/displayer/DisplayerBlockContainer.java
@@ -2,6 +2,7 @@ package com.is.mtc.displayer;
 
 import com.is.mtc.root.CardSlot;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;

--- a/java/com/is/mtc/displayer/DisplayerBlockInterface.java
+++ b/java/com/is/mtc/displayer/DisplayerBlockInterface.java
@@ -1,10 +1,12 @@
 package com.is.mtc.displayer;
 
+import org.lwjgl.util.vector.Vector2f;
+
 import com.is.mtc.Reference;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.util.vector.Vector2f;
 
 public class DisplayerBlockInterface extends GuiContainer {
 

--- a/java/com/is/mtc/displayer/DisplayerBlockRenderer.java
+++ b/java/com/is/mtc/displayer/DisplayerBlockRenderer.java
@@ -1,18 +1,20 @@
 package com.is.mtc.displayer;
 
+import org.lwjgl.opengl.GL11;
+
 import com.is.mtc.Reference;
 import com.is.mtc.card.CardItem;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Rarity;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.opengl.GL11;
 
 public class DisplayerBlockRenderer extends TileEntitySpecialRenderer {
 

--- a/java/com/is/mtc/displayer/DisplayerBlockTileEntity.java
+++ b/java/com/is/mtc/displayer/DisplayerBlockTileEntity.java
@@ -1,6 +1,7 @@
 package com.is.mtc.displayer;
 
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;

--- a/java/com/is/mtc/displayer_mono/MonoDisplayerBlock.java
+++ b/java/com/is/mtc/displayer_mono/MonoDisplayerBlock.java
@@ -4,6 +4,7 @@ import com.is.mtc.MineTradingCards;
 import com.is.mtc.Reference;
 import com.is.mtc.handler.GuiHandler;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;

--- a/java/com/is/mtc/displayer_mono/MonoDisplayerBlockContainer.java
+++ b/java/com/is/mtc/displayer_mono/MonoDisplayerBlockContainer.java
@@ -2,6 +2,7 @@ package com.is.mtc.displayer_mono;
 
 import com.is.mtc.root.CardSlot;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;

--- a/java/com/is/mtc/displayer_mono/MonoDisplayerBlockInterface.java
+++ b/java/com/is/mtc/displayer_mono/MonoDisplayerBlockInterface.java
@@ -1,10 +1,12 @@
 package com.is.mtc.displayer_mono;
 
+import org.lwjgl.util.vector.Vector2f;
+
 import com.is.mtc.Reference;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.util.vector.Vector2f;
 
 public class MonoDisplayerBlockInterface extends GuiContainer {
 

--- a/java/com/is/mtc/displayer_mono/MonoDisplayerBlockRenderer.java
+++ b/java/com/is/mtc/displayer_mono/MonoDisplayerBlockRenderer.java
@@ -1,18 +1,20 @@
 package com.is.mtc.displayer_mono;
 
+import org.lwjgl.opengl.GL11;
+
 import com.is.mtc.Reference;
 import com.is.mtc.card.CardItem;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Rarity;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.opengl.GL11;
 
 public class MonoDisplayerBlockRenderer extends TileEntitySpecialRenderer {
 

--- a/java/com/is/mtc/displayer_mono/MonoDisplayerBlockTileEntity.java
+++ b/java/com/is/mtc/displayer_mono/MonoDisplayerBlockTileEntity.java
@@ -1,6 +1,7 @@
 package com.is.mtc.displayer_mono;
 
 import com.is.mtc.displayer.DisplayerBlockTileEntity;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;

--- a/java/com/is/mtc/handler/DropHandler.java
+++ b/java/com/is/mtc/handler/DropHandler.java
@@ -1,6 +1,9 @@
 package com.is.mtc.handler;
 
+import java.util.Random;
+
 import com.is.mtc.MineTradingCards;
+
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.boss.EntityDragon;
@@ -12,8 +15,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
-
-import java.util.Random;
 
 public class DropHandler {
 
@@ -55,6 +56,7 @@ public class DropHandler {
 
 	@SubscribeEvent
 	public void onEvent(LivingDropsEvent event) {
+		
 		if (!(event.entity instanceof EntityLiving)) // Not a known living entity
 			return;
 

--- a/java/com/is/mtc/handler/GuiHandler.java
+++ b/java/com/is/mtc/handler/GuiHandler.java
@@ -14,6 +14,7 @@ import com.is.mtc.displayer_mono.MonoDisplayerBlockInterface;
 import com.is.mtc.displayer_mono.MonoDisplayerBlockTileEntity;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Tools;
+
 import cpw.mods.fml.common.network.IGuiHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;

--- a/java/com/is/mtc/pack/PackItemBase.java
+++ b/java/com/is/mtc/pack/PackItemBase.java
@@ -1,18 +1,19 @@
 package com.is.mtc.pack;
 
+import java.util.ArrayList;
+
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Rarity;
 import com.is.mtc.root.Tools;
+
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
 
 public class PackItemBase extends Item {
 

--- a/java/com/is/mtc/pack/PackItemCustom.java
+++ b/java/com/is/mtc/pack/PackItemCustom.java
@@ -1,21 +1,23 @@
 package com.is.mtc.pack;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import javax.annotation.Nullable;
+
 import com.is.mtc.Reference;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.CustomPackStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Logs;
 import com.mojang.realmsclient.gui.ChatFormatting;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 public class PackItemCustom extends PackItemBase {
 

--- a/java/com/is/mtc/pack/PackItemEdition.java
+++ b/java/com/is/mtc/pack/PackItemEdition.java
@@ -1,21 +1,22 @@
 package com.is.mtc.pack;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import com.is.mtc.Reference;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.data_manager.EditionStructure;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 public class PackItemEdition extends PackItemBase {
 

--- a/java/com/is/mtc/pack/PackItemRarity.java
+++ b/java/com/is/mtc/pack/PackItemRarity.java
@@ -1,15 +1,16 @@
 package com.is.mtc.pack;
 
+import java.util.ArrayList;
+
 import com.is.mtc.Reference;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
 
 /*
  * Pack item drop informations

--- a/java/com/is/mtc/pack/PackItemStandard.java
+++ b/java/com/is/mtc/pack/PackItemStandard.java
@@ -1,14 +1,15 @@
 package com.is.mtc.pack;
 
+import java.util.ArrayList;
+import java.util.Random;
+
 import com.is.mtc.Reference;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
-import java.util.Random;
 
 public class PackItemStandard extends PackItemBase {
 

--- a/java/com/is/mtc/packet/MTCMessageHandler.java
+++ b/java/com/is/mtc/packet/MTCMessageHandler.java
@@ -3,6 +3,7 @@ package com.is.mtc.packet;
 import com.is.mtc.binder.BinderItem;
 import com.is.mtc.binder.BinderItemInterfaceContainer;
 import com.is.mtc.root.Logs;
+
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/java/com/is/mtc/proxy/ClientProxy.java
+++ b/java/com/is/mtc/proxy/ClientProxy.java
@@ -6,7 +6,8 @@ import com.is.mtc.displayer.DisplayerBlockTileEntity;
 import com.is.mtc.displayer_mono.MonoDisplayerBlockRenderer;
 import com.is.mtc.displayer_mono.MonoDisplayerBlockTileEntity;
 import com.is.mtc.root.Logs;
-import com.is.mtc.village.VillageHandler;
+import com.is.mtc.village.VillagerHandler;
+
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -34,6 +35,6 @@ public class ClientProxy extends CommonProxy {
 
 		ClientRegistry.bindTileEntitySpecialRenderer(DisplayerBlockTileEntity.class, new DisplayerBlockRenderer());
 		ClientRegistry.bindTileEntitySpecialRenderer(MonoDisplayerBlockTileEntity.class, new MonoDisplayerBlockRenderer());
-		VillagerRegistry.instance().registerVillagerSkin(VillageHandler.TRADER_ID, new ResourceLocation("is_mtc", "textures/skins/card_master.png"));
+		VillagerRegistry.instance().registerVillagerSkin(VillagerHandler.TRADER_ID, new ResourceLocation("is_mtc", "textures/skins/card_master.png"));
 	}
 }

--- a/java/com/is/mtc/proxy/CommonProxy.java
+++ b/java/com/is/mtc/proxy/CommonProxy.java
@@ -1,6 +1,7 @@
 package com.is.mtc.proxy;
 
 import com.is.mtc.root.Logs;
+
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;

--- a/java/com/is/mtc/proxy/ServerProxy.java
+++ b/java/com/is/mtc/proxy/ServerProxy.java
@@ -2,6 +2,7 @@ package com.is.mtc.proxy;
 
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.root.Logs;
+
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;

--- a/java/com/is/mtc/root/CC_CreateCard.java
+++ b/java/com/is/mtc/root/CC_CreateCard.java
@@ -1,6 +1,9 @@
 package com.is.mtc.root;
 
+import java.util.List;
+
 import com.is.mtc.data_manager.Databank;
+
 import net.minecraft.command.CommandTime;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.item.EntityItem;
@@ -8,8 +11,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 public class CC_CreateCard extends CommandTime { // Command to create an existing card
 

--- a/java/com/is/mtc/root/CC_ForceCreateCard.java
+++ b/java/com/is/mtc/root/CC_ForceCreateCard.java
@@ -1,13 +1,13 @@
 package com.is.mtc.root;
 
+import java.util.regex.Pattern;
+
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
-
-import java.util.regex.Pattern;
 
 public class CC_ForceCreateCard extends CC_CreateCard { // Command to create a specific card. Does not have to be an existing one
 

--- a/java/com/is/mtc/root/Rarity.java
+++ b/java/com/is/mtc/root/Rarity.java
@@ -2,6 +2,7 @@ package com.is.mtc.root;
 
 import com.is.mtc.MineTradingCards;
 import com.is.mtc.card.CardItem;
+
 import net.minecraft.util.EnumChatFormatting;
 
 public class Rarity {

--- a/java/com/is/mtc/root/Tools.java
+++ b/java/com/is/mtc/root/Tools.java
@@ -1,11 +1,12 @@
 package com.is.mtc.root;
 
-import com.is.mtc.card.CardItem;
-import net.minecraft.item.ItemStack;
-
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.is.mtc.card.CardItem;
+
+import net.minecraft.item.ItemStack;
 
 public class Tools {
 

--- a/java/com/is/mtc/village/CardMasterHome.java
+++ b/java/com/is/mtc/village/CardMasterHome.java
@@ -1,14 +1,15 @@
 package com.is.mtc.village;
 
+import java.util.List;
+import java.util.Random;
+
 import com.is.mtc.root.Logs;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import net.minecraft.world.gen.structure.StructureComponent;
 import net.minecraft.world.gen.structure.StructureVillagePieces;
-
-import java.util.List;
-import java.util.Random;
 
 public class CardMasterHome extends StructureVillagePieces.House1 {
 	private int averageGroundLevel = -1;
@@ -58,7 +59,7 @@ public class CardMasterHome extends StructureVillagePieces.House1 {
 	}
 
 	protected int func_74888_b(int p_74888_1_) {
-		return VillageHandler.TRADER_ID;
+		return VillagerHandler.TRADER_ID;
 	}
 }
 

--- a/java/com/is/mtc/village/CardMasterHomeHandler.java
+++ b/java/com/is/mtc/village/CardMasterHomeHandler.java
@@ -1,10 +1,10 @@
 package com.is.mtc.village;
 
-import cpw.mods.fml.common.registry.VillagerRegistry;
-import net.minecraft.world.gen.structure.StructureVillagePieces;
-
 import java.util.List;
 import java.util.Random;
+
+import cpw.mods.fml.common.registry.VillagerRegistry;
+import net.minecraft.world.gen.structure.StructureVillagePieces;
 
 public class CardMasterHomeHandler
 		implements VillagerRegistry.IVillageCreationHandler {

--- a/java/com/is/mtc/village/VillagerHandler.java
+++ b/java/com/is/mtc/village/VillagerHandler.java
@@ -1,6 +1,9 @@
 package com.is.mtc.village;
 
+import java.util.Random;
+
 import com.is.mtc.MineTradingCards;
+
 import cpw.mods.fml.common.registry.VillagerRegistry;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.init.Items;
@@ -8,13 +11,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.village.MerchantRecipe;
 import net.minecraft.village.MerchantRecipeList;
 
-import java.util.Random;
-
-public class VillageHandler
+public class VillagerHandler
 		implements VillagerRegistry.IVillageTradeHandler {
 	public static int TRADER_ID = 7117;
 
-	public VillageHandler() {
+	public VillagerHandler() {
 		VillagerRegistry vr = VillagerRegistry.instance();
 		vr.registerVillagerId(TRADER_ID);
 	}


### PR DESCRIPTION
This push adds config options for whether the recipes to craft individual cards will be registered.
As such, I've changed the config ID to `1.1`.

In addition, I've cleaned up imports and organized some mod/config ID references.