### PR TITLE
Update drops

### DIFF
--- a/src/main/java/com/is/mtc/MineTradingCards.java
+++ b/src/main/java/com/is/mtc/MineTradingCards.java
@@ -247,7 +247,7 @@ public class MineTradingCards {
 		Configuration config = new Configuration(new File(CONF_DIR, "Mine Trading Cards.cfg"), Reference.CONFIG_VERSION, false);
 		config.load();
 		
-		// Colors
+		// === Colors ===
 		// Cards
 		CARD_COLOR_COMMON = Functions.parseColorInteger(config.getString("card_color_common", CONFIG_CAT_COLORS, "#55ff55", COLOR_ITEM_DESCRIPTION_1+"common cards. "+COLOR_ITEM_DESCRIPTION_2).trim(), Reference.COLOR_GREEN);
 		CARD_COLOR_UNCOMMON = Functions.parseColorInteger(config.getString("card_color_uncommon", CONFIG_CAT_COLORS, "#ffaa00", COLOR_ITEM_DESCRIPTION_1+"uncommon cards. "+COLOR_ITEM_DESCRIPTION_2).trim(), Reference.COLOR_GOLD);
@@ -268,28 +268,58 @@ public class MineTradingCards {
 		PACK_COLOR_LEGENDARY = Functions.parseColorInteger(config.getString("pack_color_legendary", CONFIG_CAT_COLORS, "#ff55ff", COLOR_ITEM_DESCRIPTION_1+"legendary packs. "+COLOR_ITEM_DESCRIPTION_2).trim(), Reference.COLOR_LIGHT_PURPLE);
 		PACK_COLOR_STANDARD = Functions.parseColorInteger(config.getString("pack_color_standard", CONFIG_CAT_COLORS, "#5555ff", COLOR_ITEM_DESCRIPTION_1+"standard packs. "+COLOR_ITEM_DESCRIPTION_2).trim(), Reference.COLOR_BLUE);
 		
+		// === Drops === 
 		// Drops toggle
-		DropHandler.CAN_DROP_MOB = config.getBoolean("mobs_can_drop", CONFIG_CAT_DROPS, true, "Can mobs drop packs on death");
-		DropHandler.CAN_DROP_ANIMAL = config.getBoolean("animals_can_drop", CONFIG_CAT_DROPS, false, "Can animals drop packs on death");
-		DropHandler.CAN_DROP_PLAYER = config.getBoolean("players_can_drop", CONFIG_CAT_DROPS, false, "Can players drop packs on death");
+		DropHandler.CAN_DROP_CARDS_MOB = config.getBoolean("mobs_can_drop_cards", CONFIG_CAT_DROPS, true, "Mobs will drop cards on death.");
+		DropHandler.CAN_DROP_CARDS_ANIMAL = config.getBoolean("animals_can_drop_cards", CONFIG_CAT_DROPS, false, "Animals will drop cards on death.");
+		DropHandler.CAN_DROP_CARDS_PLAYER = config.getBoolean("players_can_drop_cards", CONFIG_CAT_DROPS, false, "Players will drop cards on death.");
+		DropHandler.CAN_DROP_PACKS_MOB = config.getBoolean("mobs_can_drop_packs", CONFIG_CAT_DROPS, true, "Mobs will drop packs on death.");
+		DropHandler.CAN_DROP_PACKS_ANIMAL = config.getBoolean("animals_can_drop_packs", CONFIG_CAT_DROPS, false, "Animals will drop packs on death.");
+		DropHandler.CAN_DROP_PACKS_PLAYER = config.getBoolean("players_can_drop_packs", CONFIG_CAT_DROPS, false, "Players will drop packs on death.");
+		// Tiered card drop rates
+		DropHandler.CARD_DROP_RATE_COM = config.getFloat("card_drop_rate_common", CONFIG_CAT_DROPS, 16, 0, Float.MAX_VALUE, "Chance out of X to drop common cards. Set to 0 to disable.");
+		DropHandler.CARD_DROP_RATE_UNC = config.getFloat("card_drop_rate_uncommon", CONFIG_CAT_DROPS, 32, 0, Float.MAX_VALUE, "Chance out of X to drop uncommon cards. Set to 0 to disable.");
+		DropHandler.CARD_DROP_RATE_RAR = config.getFloat("card_drop_rate_rare", CONFIG_CAT_DROPS, 48, 0, Float.MAX_VALUE, "Chance out of X to drop rare cards. Set to 0 to disable.");
+		DropHandler.CARD_DROP_RATE_ANC = config.getFloat("card_drop_rate_ancient", CONFIG_CAT_DROPS, 64, 0, Float.MAX_VALUE, "Chance out of X to drop ancient cards. Set to 0 to disable.");
+		DropHandler.CARD_DROP_RATE_LEG = config.getFloat("card_drop_rate_legendary", CONFIG_CAT_DROPS, 256, 0, Float.MAX_VALUE, "Chance out of X to drop legendary cards. Set to 0 to disable.");
 		// Tiered pack drop rates
-		DropHandler.DROP_RATE_COM = config.getInt("pack_drop_rate_common", CONFIG_CAT_DROPS, 16, 0, Integer.MAX_VALUE, "Chance out of X to drop common packs");
-		DropHandler.DROP_RATE_UNC = config.getInt("pack_drop_rate_uncommon", CONFIG_CAT_DROPS, 32, 0, Integer.MAX_VALUE, "Chance out of X to drop uncommon packs");
-		DropHandler.DROP_RATE_RAR = config.getInt("pack_drop_rate_rare", CONFIG_CAT_DROPS, 48, 0, Integer.MAX_VALUE, "Chance out of X to drop rare packs");
-		DropHandler.DROP_RATE_ANC = config.getInt("pack_drop_rate_ancient", CONFIG_CAT_DROPS, 64, 0, Integer.MAX_VALUE, "Chance out of X to drop ancient packs");
-		DropHandler.DROP_RATE_LEG = config.getInt("pack_drop_rate_legendary", CONFIG_CAT_DROPS, 256, 0, Integer.MAX_VALUE, "Chance out of X to drop legendary packs");
+		DropHandler.PACK_DROP_RATE_COM = config.getFloat("pack_drop_rate_common", CONFIG_CAT_DROPS, 16, 0, Float.MAX_VALUE, "Chance out of X to drop common packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_UNC = config.getFloat("pack_drop_rate_uncommon", CONFIG_CAT_DROPS, 32, 0, Float.MAX_VALUE, "Chance out of X to drop uncommon packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_RAR = config.getFloat("pack_drop_rate_rare", CONFIG_CAT_DROPS, 48, 0, Float.MAX_VALUE, "Chance out of X to drop rare packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_ANC = config.getFloat("pack_drop_rate_ancient", CONFIG_CAT_DROPS, 64, 0, Float.MAX_VALUE, "Chance out of X to drop ancient packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_LEG = config.getFloat("pack_drop_rate_legendary", CONFIG_CAT_DROPS, 256, 0, Float.MAX_VALUE, "Chance out of X to drop legendary packs. Set to 0 to disable.");
 		// Non-tiered pack drop rates
-		DropHandler.DROP_RATE_STD = config.getInt("pack_drop_rate_standard", CONFIG_CAT_DROPS, 40, 0, Integer.MAX_VALUE, "Chance out of X to drop standard packs");
-		DropHandler.DROP_RATE_EDT = config.getInt("pack_drop_rate_edition", CONFIG_CAT_DROPS, 40, 0, Integer.MAX_VALUE, "Chance out of X to drop set-specific (edition) packs");
-		DropHandler.DROP_RATE_CUSTOM = config.getInt("pack_drop_rate_custom", CONFIG_CAT_DROPS, 40, 0, Integer.MAX_VALUE, "Chance out of X to drop custom packs");
+		DropHandler.PACK_DROP_RATE_STD = config.getFloat("pack_drop_rate_standard", CONFIG_CAT_DROPS, 40, 0, Float.MAX_VALUE, "Chance out of X to drop standard packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_EDT = config.getFloat("pack_drop_rate_edition", CONFIG_CAT_DROPS, 40, 0, Float.MAX_VALUE, "Chance out of X to drop set-specific (edition) packs. Set to 0 to disable.");
+		DropHandler.PACK_DROP_RATE_CUS = config.getFloat("pack_drop_rate_custom", CONFIG_CAT_DROPS, 40, 0, Float.MAX_VALUE, "Chance out of X to drop custom packs. Set to 0 to disable.");
+		// Other
+		DropHandler.ONLY_ONE_DROP = config.getBoolean("only_one_drop", CONFIG_CAT_DROPS, false, "If true, entities will not drop more than one MTC item at once.");
+		// Boss drops
+		DropHandler.ENDER_DRAGON_DROPS = config.getStringList("ender_dragon_drops", CONFIG_CAT_DROPS, DropHandler.ENDER_DRAGON_DROPS_DEFAULT,
+				"List of MTC drops from the Ender Dragon. Entries are of the form:"
+				+ "\ndrop_item:float_amount"
+				+ "\nPossible drop_item values are:"
+				+ "\n[common/uncommon/rare/ancient/legendary/standard/edition/custom]_pack or [common/uncommon/rare/ancient/legendary]_card."
+				+ "\nfloat_amount is an either an integer representing the number of this item to drop, or a float like 4.7, where e.g. 70%, 5 will be dropped; otherwise 4 will."
+				+ "\nThis list applies even if \"can_drop\" is false."
+				);
+		// Boss drops
+		DropHandler.BOSS_DROPS = config.getStringList("boss_drops", CONFIG_CAT_DROPS, DropHandler.BOSS_DROPS_DEFAULT,
+				"List of MTC drops from the bosses that aren't the Ender Dragon. Entries are of the form:"
+				+ "\ndrop_item:float_amount"
+				+ "\nPossible drop_item values are:"
+				+ "\n[common/uncommon/rare/ancient/legendary/standard/edition/custom]_pack or [common/uncommon/rare/ancient/legendary]_card."
+				+ "\nfloat_amount is an either an integer representing the number of this item to drop, or a float like 4.7, where e.g. 70%, 5 will be dropped; otherwise 4 will."
+				+ "\nThis list applies even if \"can_drop\" is false."
+				);
 		
-		// Logging
+		// === Logging ===
 		Logs.ENABLE_DEV_LOGS = config.getBoolean("devlog_enabled", CONFIG_CAT_LOGS, false, "Enable developer logs");
 		
-		// Recipes
+		// === Recipes ===
 		ENABLE_CARD_RECIPES = config.getBoolean("enable_card_recipes", CONFIG_CAT_RECIPES, true, "Enable recipes for crafting individual cards");
 		
-		// Villager
+		// === Villager ===
 		VillagerHandler.ID_CARD_MASTER = config.getInt("card_master_id", CONFIG_CAT_VILLAGERS, 7117, 6, Integer.MAX_VALUE, "Profession ID for the card master villager");
 		VillagerHandler.ID_CARD_TRADER = config.getInt("card_trader_id", CONFIG_CAT_VILLAGERS, 7118, 6, Integer.MAX_VALUE, "Profession ID for the card trader villager");
 		VillagerHandler.CARD_MASTER_TRADE_LIST = config.getStringList("card_master_trades", CONFIG_CAT_VILLAGERS, VillagerHandler.CARD_MASTER_TRADE_LIST_DEFAULT,
@@ -315,7 +345,7 @@ public class MineTradingCards {
 		CardMasterHomeHandler.SHOP_WEIGHT = config.getInt("card_shop_weight", CONFIG_CAT_VILLAGERS, 5, 0, 100, "Weighting for selection when villages generate. Farms and wood huts are 3, church is 20.");
 		CardMasterHomeHandler.SHOP_MAX_NUMBER = config.getInt("card_shop_max_number", CONFIG_CAT_VILLAGERS, 1, 0, 32, "Maximum number of card master shops that can spawn per village");
 		
-		// Update Checker
+		// === Update Checker ===
 		ENABLE_UPDATE_CHECKER = config.getBoolean("enable_update_checker", CONFIG_CAT_UPDATES, true, "Displays a client-side chat message on login if there's an update available.");
 		
 		

--- a/src/main/java/com/is/mtc/handler/DropHandler.java
+++ b/src/main/java/com/is/mtc/handler/DropHandler.java
@@ -1,96 +1,289 @@
 package com.is.mtc.handler;
 
+import java.util.Hashtable;
+import java.util.Random;
+
 import com.is.mtc.MineTradingCards;
+import com.is.mtc.root.Logs;
+import com.is.mtc.util.Functions;
+import com.is.mtc.util.Reference;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.boss.EntityDragon;
-import net.minecraft.entity.boss.EntityWither;
+import net.minecraft.entity.boss.IBossDisplayData;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 
 public class DropHandler {
 
-	public static boolean CAN_DROP_ANIMAL = false;
-	public static boolean CAN_DROP_PLAYER = false;
-	public static boolean CAN_DROP_MOB = true;
-
+	public static boolean CAN_DROP_CARDS_ANIMAL = false;
+	public static boolean CAN_DROP_CARDS_PLAYER = false;
+	public static boolean CAN_DROP_CARDS_MOB = true;
+	public static boolean CAN_DROP_PACKS_ANIMAL = false;
+	public static boolean CAN_DROP_PACKS_PLAYER = false;
+	public static boolean CAN_DROP_PACKS_MOB = true;
+	public static boolean ONLY_ONE_DROP = false;
+	
 	// 1 chance out of DROP_RATE_X (test order)
-	public static int DROP_RATE_COM = 16; // (7)
-	public static int DROP_RATE_UNC = 32; // (6)
-	public static int DROP_RATE_RAR = 48; // (5)
-	public static int DROP_RATE_ANC = 64; // (2)
-	public static int DROP_RATE_LEG = 256; // (1)
+	public static float CARD_DROP_RATE_COM = 16F;
+	public static float CARD_DROP_RATE_UNC = 32F;
+	public static float CARD_DROP_RATE_RAR = 48F;
+	public static float CARD_DROP_RATE_ANC = 64F;
+	public static float CARD_DROP_RATE_LEG = 256F;
 
-	public static int DROP_RATE_STD = 56; // (4)
-	public static int DROP_RATE_EDT = 56; // (3)
-	public static int DROP_RATE_CUSTOM = 56;
+	public static float PACK_DROP_RATE_COM = 16F;
+	public static float PACK_DROP_RATE_UNC = 32F;
+	public static float PACK_DROP_RATE_RAR = 48F;
+	public static float PACK_DROP_RATE_ANC = 64F;
+	public static float PACK_DROP_RATE_LEG = 256F;
 
+	public static float PACK_DROP_RATE_STD = 40F;
+	public static float PACK_DROP_RATE_EDT = 40F;
+	public static float PACK_DROP_RATE_CUS = 40F;
+	
+	public static final String[] ENDER_DRAGON_DROPS_DEFAULT = new String[] {
+			"common_pack:7",
+			"uncommon_pack:5",
+			"rare_pack:3",
+			"ancient_pack:2",
+			"legendary_pack:1"
+	};
+	public static String[] ENDER_DRAGON_DROPS = ENDER_DRAGON_DROPS_DEFAULT;
+	
+	public static final String[] BOSS_DROPS_DEFAULT = new String[] {
+			"common_pack:3",
+			"uncommon_pack:3",
+			"rare_pack:2",
+			"ancient_pack:1",
+			"legendary_pack:0.25"
+	};
+	public static String[] BOSS_DROPS = BOSS_DROPS_DEFAULT;
+	
 	private void addDrop(Item drop, LivingDropsEvent event, int count) {
-		ItemStack itemToDrop = new ItemStack(drop);
-
-		event.drops.add(new EntityItem(event.entity.worldObj, event.entity.posX,
-				event.entity.posY, event.entity.posZ, itemToDrop));
+		if (count==0) {return;}
+		
+		ItemStack dropStack = new ItemStack(drop, count);
+		event.drops.add(new EntityItem(event.entity.worldObj, event.entity.posX, event.entity.posY, event.entity.posZ, dropStack));
 	}
-
+	
 	private void addDrop(Item drop, LivingDropsEvent event) {
 		addDrop(drop, event, 1);
 	}
 
-	private void testDrop(int rate, Item drop, LivingDropsEvent event) {
-		if (rate <= 0) {
-			return;
+	private boolean testWhetherDrop(float rate, Random random) {
+		if (rate == 0) {
+			return false;
 		}
-		int dv = event.entity.worldObj.rand.nextInt(rate);
-
-		if (dv == 0) {
-			addDrop(drop, event);
-		}
+		return random.nextFloat()*rate < 1F;
 	}
-
+	
+	private Hashtable<String, Integer> addToDropDict(Hashtable<String, Integer> dict, String key, int valueToAdd) {
+		dict.put(key, dict.get(key)+valueToAdd);
+		return dict;
+	}
+	
 	@SubscribeEvent
 	public void onEvent(LivingDropsEvent event) {
 		
-		if (!(event.entity instanceof EntityLiving)) // Not a known living entity
-			return;
-
-		if (!CAN_DROP_MOB && event.entity instanceof EntityMob)
-			return;
-
-		if (!CAN_DROP_ANIMAL && event.entity instanceof EntityAnimal)
-			return;
-
-		if (!CAN_DROP_PLAYER && event.entity instanceof EntityPlayer)
-			return;
-
-		if (event.entity instanceof EntityDragon) { // 18 packs
-			addDrop(MineTradingCards.packLegendary, event);
-			addDrop(MineTradingCards.packAncient, event, 2);
-			addDrop(MineTradingCards.packRare, event, 3);
-			addDrop(MineTradingCards.packUncommon, event, 5);
-			addDrop(MineTradingCards.packCommon, event, 7);
+		// === HANDLE PACK DROPS === //
+		
+		// Ignore if drops are not enabled
+		if (!(event.entity instanceof EntityLiving)) {return;}
+		if (!CAN_DROP_CARDS_MOB && !CAN_DROP_PACKS_MOB && event.entity instanceof EntityMob && !(event.entity instanceof IBossDisplayData)) {return;}
+		if (!CAN_DROP_CARDS_ANIMAL && !CAN_DROP_PACKS_ANIMAL && event.entity instanceof EntityAnimal && !(event.entity instanceof IBossDisplayData)) {return;}
+		if (!CAN_DROP_CARDS_PLAYER && !CAN_DROP_PACKS_PLAYER && event.entity instanceof EntityPlayer && !(event.entity instanceof IBossDisplayData)) {return;}
+		
+		// Set flags to determine what can drop
+		boolean willDropCards = false;
+		boolean willDropPacks = false;
+		if (event.entity instanceof EntityMob)
+		{
+			willDropCards = CAN_DROP_CARDS_MOB;
+			willDropPacks = CAN_DROP_PACKS_MOB;
 		}
-
-		if (event.entity instanceof EntityWither) { // 18 packs
-			testDrop(4, MineTradingCards.packLegendary, event); // 1 chance on 4 to drop a pl
-			addDrop(MineTradingCards.packAncient, event, 1);
-			addDrop(MineTradingCards.packRare, event, 2);
-			addDrop(MineTradingCards.packUncommon, event, 3);
-			addDrop(MineTradingCards.packCommon, event, 3);
+		else if (event.entity instanceof EntityAnimal)
+		{
+			willDropCards = CAN_DROP_CARDS_ANIMAL;
+			willDropPacks = CAN_DROP_PACKS_ANIMAL;
 		}
-
-		testDrop(DROP_RATE_LEG, MineTradingCards.packLegendary, event); // Legendary (leg)
-		testDrop(DROP_RATE_ANC, MineTradingCards.packAncient, event); // Ancient (anc)
-		testDrop(DROP_RATE_CUSTOM, MineTradingCards.packCustom, event); // Custom
-		testDrop(DROP_RATE_EDT, MineTradingCards.packEdition, event); // Edition (edt)
-		testDrop(DROP_RATE_STD, MineTradingCards.packStandard, event); // Standard (std)
-		testDrop(DROP_RATE_RAR, MineTradingCards.packRare, event); // Rare (rar)
-		testDrop(DROP_RATE_UNC, MineTradingCards.packUncommon, event); // Uncommon (unc)
-		testDrop(DROP_RATE_COM, MineTradingCards.packCommon, event); // Common (com)
+		else if (event.entity instanceof EntityPlayer)
+		{
+			willDropCards = CAN_DROP_CARDS_PLAYER;
+			willDropPacks = CAN_DROP_PACKS_PLAYER;
+		}
+		
+		Random random = event.entity.worldObj.rand;
+		
+		// Initialize empty dictionary
+		Hashtable<String, Integer> dropCountDict = new Hashtable<String, Integer>();
+		dropCountDict.put(Reference.KEY_CARD_COM, 0);
+		dropCountDict.put(Reference.KEY_CARD_UNC, 0);
+		dropCountDict.put(Reference.KEY_CARD_RAR, 0);
+		dropCountDict.put(Reference.KEY_CARD_ANC, 0);
+		dropCountDict.put(Reference.KEY_CARD_LEG, 0);
+		
+		dropCountDict.put(Reference.KEY_PACK_COM, 0);
+		dropCountDict.put(Reference.KEY_PACK_UNC, 0);
+		dropCountDict.put(Reference.KEY_PACK_RAR, 0);
+		dropCountDict.put(Reference.KEY_PACK_ANC, 0);
+		dropCountDict.put(Reference.KEY_PACK_LEG, 0);
+		dropCountDict.put(Reference.KEY_PACK_STD, 0);
+		dropCountDict.put(Reference.KEY_PACK_EDT, 0);
+		dropCountDict.put(Reference.KEY_PACK_CUS, 0);
+		
+		// Increment drops based on successful triggers
+		Hashtable<String, Integer> randomizedDrops = new Hashtable<String, Integer>();
+		randomizedDrops.put(Reference.KEY_CARD_COM, 0);
+		randomizedDrops.put(Reference.KEY_CARD_UNC, 0);
+		randomizedDrops.put(Reference.KEY_CARD_RAR, 0);
+		randomizedDrops.put(Reference.KEY_CARD_ANC, 0);
+		randomizedDrops.put(Reference.KEY_CARD_LEG, 0);
+		
+		randomizedDrops.put(Reference.KEY_PACK_COM, 0);
+		randomizedDrops.put(Reference.KEY_PACK_UNC, 0);
+		randomizedDrops.put(Reference.KEY_PACK_RAR, 0);
+		randomizedDrops.put(Reference.KEY_PACK_ANC, 0);
+		randomizedDrops.put(Reference.KEY_PACK_LEG, 0);
+		randomizedDrops.put(Reference.KEY_PACK_STD, 0);
+		randomizedDrops.put(Reference.KEY_PACK_EDT, 0);
+		randomizedDrops.put(Reference.KEY_PACK_CUS, 0);
+		int dropsGenerated = 0;
+		
+		if (willDropCards && testWhetherDrop(CARD_DROP_RATE_LEG, random)) {addToDropDict(randomizedDrops, Reference.KEY_CARD_LEG, 1); dropsGenerated++;}
+		if (willDropCards && testWhetherDrop(CARD_DROP_RATE_ANC, random)) {addToDropDict(randomizedDrops, Reference.KEY_CARD_ANC, 1); dropsGenerated++;}
+		if (willDropCards && testWhetherDrop(CARD_DROP_RATE_RAR, random)) {addToDropDict(randomizedDrops, Reference.KEY_CARD_RAR, 1); dropsGenerated++;}
+		if (willDropCards && testWhetherDrop(CARD_DROP_RATE_UNC, random)) {addToDropDict(randomizedDrops, Reference.KEY_CARD_UNC, 1); dropsGenerated++;}
+		if (willDropCards && testWhetherDrop(CARD_DROP_RATE_COM, random)) {addToDropDict(randomizedDrops, Reference.KEY_CARD_COM, 1); dropsGenerated++;}
+		
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_LEG, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_LEG, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_ANC, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_ANC, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_CUS, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_CUS, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_EDT, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_EDT, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_STD, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_STD, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_RAR, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_RAR, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_UNC, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_UNC, 1); dropsGenerated++;}
+		if (willDropPacks && testWhetherDrop(PACK_DROP_RATE_COM, random)) {addToDropDict(randomizedDrops, Reference.KEY_PACK_COM, 1); dropsGenerated++;}
+		
+		if (dropsGenerated > 0)
+		{
+			if (ONLY_ONE_DROP)
+			{
+				// Select only one from the above set
+				String dropSelected = (String) Functions.weightedRandom(
+						new String[] {
+								Reference.KEY_CARD_LEG,
+								Reference.KEY_CARD_ANC,
+								Reference.KEY_CARD_RAR,
+								Reference.KEY_CARD_UNC,
+								Reference.KEY_CARD_COM,
+								
+								Reference.KEY_PACK_LEG,
+								Reference.KEY_PACK_ANC,
+								Reference.KEY_PACK_CUS,
+								Reference.KEY_PACK_EDT,
+								Reference.KEY_PACK_STD,
+								Reference.KEY_PACK_RAR,
+								Reference.KEY_PACK_UNC,
+								Reference.KEY_PACK_COM
+								},
+						new double[] {
+								randomizedDrops.get(Reference.KEY_CARD_LEG) * (CARD_DROP_RATE_LEG>0 ? 1D/CARD_DROP_RATE_LEG : 0),
+								randomizedDrops.get(Reference.KEY_CARD_ANC) * (CARD_DROP_RATE_ANC>0 ? 1D/CARD_DROP_RATE_ANC : 0),
+								randomizedDrops.get(Reference.KEY_CARD_RAR) * (CARD_DROP_RATE_RAR>0 ? 1D/CARD_DROP_RATE_RAR : 0),
+								randomizedDrops.get(Reference.KEY_CARD_UNC) * (CARD_DROP_RATE_UNC>0 ? 1D/CARD_DROP_RATE_UNC : 0),
+								randomizedDrops.get(Reference.KEY_CARD_COM) * (CARD_DROP_RATE_COM>0 ? 1D/CARD_DROP_RATE_COM : 0),
+								
+								randomizedDrops.get(Reference.KEY_PACK_LEG) * (PACK_DROP_RATE_LEG>0 ? 1D/PACK_DROP_RATE_LEG : 0),
+								randomizedDrops.get(Reference.KEY_PACK_ANC) * (PACK_DROP_RATE_ANC>0 ? 1D/PACK_DROP_RATE_ANC : 0),
+								randomizedDrops.get(Reference.KEY_PACK_CUS) * (PACK_DROP_RATE_CUS>0 ? 1D/PACK_DROP_RATE_CUS : 0),
+								randomizedDrops.get(Reference.KEY_PACK_EDT) * (PACK_DROP_RATE_EDT>0 ? 1D/PACK_DROP_RATE_EDT : 0),
+								randomizedDrops.get(Reference.KEY_PACK_STD) * (PACK_DROP_RATE_STD>0 ? 1D/PACK_DROP_RATE_STD : 0),
+								randomizedDrops.get(Reference.KEY_PACK_RAR) * (PACK_DROP_RATE_RAR>0 ? 1D/PACK_DROP_RATE_RAR : 0),
+								randomizedDrops.get(Reference.KEY_PACK_UNC) * (PACK_DROP_RATE_UNC>0 ? 1D/PACK_DROP_RATE_UNC : 0),
+								randomizedDrops.get(Reference.KEY_PACK_COM) * (PACK_DROP_RATE_COM>0 ? 1D/PACK_DROP_RATE_COM : 0)
+								},
+						random
+						);
+				
+				if (dropSelected != null) {
+					addToDropDict(dropCountDict, dropSelected, 1);
+				}
+			}
+			else
+			{
+				// Add every triggered drop
+				addToDropDict(dropCountDict, Reference.KEY_CARD_LEG, randomizedDrops.get(Reference.KEY_CARD_LEG));
+				addToDropDict(dropCountDict, Reference.KEY_CARD_ANC, randomizedDrops.get(Reference.KEY_CARD_ANC));
+				addToDropDict(dropCountDict, Reference.KEY_CARD_RAR, randomizedDrops.get(Reference.KEY_CARD_RAR));
+				addToDropDict(dropCountDict, Reference.KEY_CARD_UNC, randomizedDrops.get(Reference.KEY_CARD_UNC));
+				addToDropDict(dropCountDict, Reference.KEY_CARD_COM, randomizedDrops.get(Reference.KEY_CARD_COM));
+				
+				addToDropDict(dropCountDict, Reference.KEY_PACK_LEG, randomizedDrops.get(Reference.KEY_PACK_LEG));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_ANC, randomizedDrops.get(Reference.KEY_PACK_ANC));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_CUS, randomizedDrops.get(Reference.KEY_PACK_CUS));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_EDT, randomizedDrops.get(Reference.KEY_PACK_EDT));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_STD, randomizedDrops.get(Reference.KEY_PACK_STD));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_RAR, randomizedDrops.get(Reference.KEY_PACK_RAR));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_UNC, randomizedDrops.get(Reference.KEY_PACK_UNC));
+				addToDropDict(dropCountDict, Reference.KEY_PACK_COM, randomizedDrops.get(Reference.KEY_PACK_COM));
+			}
+		}
+		
+		// Add set drops to bosses
+		if (event.entity instanceof EntityDragon) {
+			for (String line : ENDER_DRAGON_DROPS) {
+				try {
+					String[] split_config_entry = line.toLowerCase().trim().split(":");
+					
+					float drop_count = MathHelper.clamp_float(Float.parseFloat(split_config_entry[1].trim()), 0F, 64F);
+					int drop_count_characteristic = (int) drop_count;
+					float drop_count_mantissa = drop_count % 1;
+					
+					addToDropDict(dropCountDict, split_config_entry[0].trim(), drop_count_characteristic + (random.nextFloat() < drop_count_mantissa ? 1 : 0));
+				}
+				catch (Exception e) {
+					Logs.errLog("Malformed config entry: " + line);
+				}
+			}
+		}
+		else if (event.entity instanceof IBossDisplayData) {
+			for (String line : BOSS_DROPS) {
+				try {
+					String[] split_config_entry = line.toLowerCase().trim().split(":");
+					
+					float drop_count = MathHelper.clamp_float(Float.parseFloat(split_config_entry[1].trim()), 0F, 64F);
+					int drop_count_characteristic = (int) drop_count;
+					float drop_count_mantissa = drop_count % 1;
+					
+					addToDropDict(dropCountDict, split_config_entry[0].trim(), drop_count_characteristic + (random.nextFloat() < drop_count_mantissa ? 1 : 0));
+				}
+				catch (Exception e) {
+					Logs.errLog("Malformed config entry: " + line);
+				}
+			}
+		}
+		
+		// Add all the drops
+		addDrop(MineTradingCards.cardLegendary, event, dropCountDict.get(Reference.KEY_CARD_LEG));
+		addDrop(MineTradingCards.cardAncient, event, dropCountDict.get(Reference.KEY_CARD_ANC));
+		addDrop(MineTradingCards.cardRare, event, dropCountDict.get(Reference.KEY_CARD_RAR));
+		addDrop(MineTradingCards.cardUncommon, event, dropCountDict.get(Reference.KEY_CARD_UNC));
+		addDrop(MineTradingCards.cardCommon, event, dropCountDict.get(Reference.KEY_CARD_COM));
+		
+		addDrop(MineTradingCards.packLegendary, event, dropCountDict.get(Reference.KEY_PACK_LEG));
+		addDrop(MineTradingCards.packAncient, event, dropCountDict.get(Reference.KEY_PACK_ANC));
+		addDrop(MineTradingCards.packCustom, event, dropCountDict.get(Reference.KEY_PACK_CUS));
+		addDrop(MineTradingCards.packEdition, event, dropCountDict.get(Reference.KEY_PACK_EDT));
+		addDrop(MineTradingCards.packStandard, event, dropCountDict.get(Reference.KEY_PACK_STD));
+		addDrop(MineTradingCards.packRare, event, dropCountDict.get(Reference.KEY_PACK_RAR));
+		addDrop(MineTradingCards.packUncommon, event, dropCountDict.get(Reference.KEY_PACK_UNC));
+		addDrop(MineTradingCards.packCommon, event, dropCountDict.get(Reference.KEY_PACK_COM));
 	}
 }

--- a/src/main/java/com/is/mtc/util/Functions.java
+++ b/src/main/java/com/is/mtc/util/Functions.java
@@ -1,5 +1,6 @@
 package com.is.mtc.util;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -577,5 +578,44 @@ public class Functions {
 //		int b = safe_int&255;
     			
 		return safe_int;
+    }
+    
+    /**
+     * Inputs an array of objects and a corresponding array of weights, and returns a randomly-selected element
+     * with a probability proportional to its weight.
+     * 
+     * These inputs must be equal length. If they are not, you get back null.
+     * Additionally, and this goes without saying: the individual weights must be non-negative and their sum must be positive.
+     * 
+     * Adapted from https://stackoverflow.com/questions/6737283/weighted-randomness-in-java
+     */
+    public static Object weightedRandom(Object elementArray, double[] weightArray, Random random)
+    {
+    	if (Array.getLength(elementArray) != weightArray.length) {return null;}
+    	else
+    	{
+    		// Compute the total weight of all items together
+    		double totalWeight = 0D;
+    		for (int i=0; i<weightArray.length; i++ )
+    		{
+    			totalWeight += weightArray[i];
+    		}
+    		if (totalWeight <= 0) {return null;}
+    		
+    		// Now choose a random item
+    		int randomIndex = -1;
+    		double randomObject = random.nextDouble() * totalWeight;
+    		for (int i = 0; i < Array.getLength(elementArray); ++i)
+    		{
+    			randomObject -= weightArray[i];
+    		    if (randomObject <= 0.0d)
+    		    {
+    		        randomIndex = i;
+    		        break;
+    		    }
+    		}
+    		
+    		return Array.get(elementArray, randomIndex);
+    	}
     }
 }

--- a/src/main/java/com/is/mtc/util/Reference.java
+++ b/src/main/java/com/is/mtc/util/Reference.java
@@ -33,6 +33,21 @@ public class Reference {
 	// Custom
 	public static final int COLOR_BROWN = 0xad7030;
 	
+	// Drops
+	public static final String KEY_CARD_COM = "common_card";
+	public static final String KEY_CARD_UNC = "uncommon_card";
+	public static final String KEY_CARD_RAR = "rare_card";
+	public static final String KEY_CARD_ANC = "ancient_card";
+	public static final String KEY_CARD_LEG = "legendary_card";
+	public static final String KEY_PACK_COM = "common_pack";
+	public static final String KEY_PACK_UNC = "uncommon_pack";
+	public static final String KEY_PACK_RAR = "rare_pack";
+	public static final String KEY_PACK_ANC = "ancient_pack";
+	public static final String KEY_PACK_LEG = "legendary_pack";
+	public static final String KEY_PACK_STD = "standard_pack";
+	public static final String KEY_PACK_EDT = "edition_pack";
+	public static final String KEY_PACK_CUS = "custom_pack";
+	
 	// Textures
 	public static final String ITEM_CARD_GRAYSCALE = ":card_grayscale";
 	public static final String ITEM_CARD_OVERLAY = ":card_overlay";

--- a/src/main/java/com/is/mtc/village/VillagerHandler.java
+++ b/src/main/java/com/is/mtc/village/VillagerHandler.java
@@ -10,6 +10,7 @@ import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
+import com.is.mtc.util.Reference;
 
 import cpw.mods.fml.common.registry.VillagerRegistry;
 import net.minecraft.entity.passive.EntityVillager;
@@ -103,48 +104,48 @@ public class VillagerHandler
 			item = Items.diamond;
 		}
 		// Packs
-		else if (item_key.equals("common_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_COM)) {
 			item = MineTradingCards.packCommon;
 		}
-		else if (item_key.equals("uncommon_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_UNC)) {
 			item = MineTradingCards.packUncommon;
 		}
-		else if (item_key.equals("rare_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_RAR)) {
 			item = MineTradingCards.packRare;
 		}
-		else if (item_key.equals("ancient_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_ANC)) {
 			item = MineTradingCards.packAncient;
 		}
-		else if (item_key.equals("legendary_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_LEG)) {
 			item = MineTradingCards.packLegendary;
 		}
-		else if (item_key.equals("standard_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_STD)) {
 			item = MineTradingCards.packStandard;
 		}
-		else if (item_key.equals("edition_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_EDT)) {
 			item = MineTradingCards.packEdition;
 		}
-		else if (item_key.equals("custom_pack")) {
+		else if (item_key.equals(Reference.KEY_PACK_CUS)) {
 			item = MineTradingCards.packCustom;
 		}
 		// Cards
-		else if (item_key.equals("common_card") ||item_key.equals("common_card_random")) {
+		else if (item_key.equals(Reference.KEY_CARD_COM) ||item_key.equals(Reference.KEY_CARD_COM+"_random")) {
 			item = MineTradingCards.cardCommon;
 			rarity = Rarity.COMMON;
 		}
-		else if (item_key.equals("uncommon_card") ||item_key.equals("uncommon_card_random")) {
+		else if (item_key.equals(Reference.KEY_CARD_UNC) ||item_key.equals(Reference.KEY_CARD_UNC+"_random")) {
 			item = MineTradingCards.cardUncommon;
 			rarity = Rarity.UNCOMMON;
 		}
-		else if (item_key.equals("rare_card") || item_key.equals("rare_card_random")) {
+		else if (item_key.equals(Reference.KEY_CARD_RAR) || item_key.equals(Reference.KEY_CARD_RAR+"_random")) {
 			item = MineTradingCards.cardRare;
 			rarity = Rarity.RARE;
 		}
-		else if (item_key.equals("ancient_card") || item_key.equals("ancient_card_random")) {
+		else if (item_key.equals(Reference.KEY_CARD_ANC) || item_key.equals(Reference.KEY_CARD_ANC+"_random")) {
 			item = MineTradingCards.cardAncient;
 			rarity = Rarity.ANCIENT;
 		}
-		else if (item_key.equals("legendary_card") || item_key.equals("legendary_card_random")) {
+		else if (item_key.equals(Reference.KEY_CARD_LEG) || item_key.equals(Reference.KEY_CARD_LEG+"_random")) {
 			item = MineTradingCards.cardLegendary;
 			rarity = Rarity.LEGENDARY;
 		}


### PR DESCRIPTION
I've refactored the mob drop event so that all potentially dropped items are tallied, and then dropped in order of item type. This allows additional packs dropped by bosses to be bundled together.

To the configs, I've done a number of things, which will either add new config options, OR in some cases change what's there:

-Added full customization to the drops from the Ender Dragon, or other bosses.
-Changed the drop rates for packs to use floats instead of integers, so that someone could do something like 1 in 2.5 (40%).
-Added drop options for cards
-Renamed original drop options to specify that they're for packs
-Added option to consolidate random drops, so that entities will drop at most one item (rather than independently dropping multiple types)