### PR TITLE
Add controls to pack contents

### DIFF
--- a/src/main/java/com/is/mtc/MineTradingCards.java
+++ b/src/main/java/com/is/mtc/MineTradingCards.java
@@ -83,6 +83,7 @@ public class MineTradingCards {
 	public static final String CONFIG_CAT_COLORS = "colors";
 	public static final String CONFIG_CAT_DROPS = "drops";
 	public static final String CONFIG_CAT_LOGS = "logs";
+	public static final String CONFIG_CAT_PACK_CONTENTS = "pack contents";
 	public static final String CONFIG_CAT_RECIPES = "recipes";
 	public static final String CONFIG_CAT_UPDATES = "updates";
 	public static final String CONFIG_CAT_VILLAGERS = "villagers";
@@ -126,8 +127,17 @@ public class MineTradingCards {
 			return MineTradingCards.packStandard;
 		}
 	};
-	//-
-
+	
+	private static final String cardPackDistributionDescription(String rarity, boolean allowNx) {
+		return "Number and type of cards dropped when a "+rarity+" pack is opened. Entries are of the form:"
+		+ "\nNxW:W:W:W:W" + (allowNx ? " or Nx" : "")
+		+ "\nN is the number of cards added from this row. It can be an integer (e.g. 5) or it can be a float like 3.4 (40% of the time 4 will be generated; otherwise 3 will)."
+		+ "\nx is just the letter x. Leave this as is."
+		+ "\nW:W:W:W:W:W is a distribution of rarity weights representing Com:Unc:Rar:Anc:Leg. Each card generated from this row will be drawn from this distribution. "
+		+ "For example: 0:1:0:0:1 has an equal chance of being an Uncommon or Legendary card. 2:1:1:1:1 can be any rarity, but is twice as likely to be "+rarity+" as the other rarities."
+		+ (allowNx ? "\nFor Nx formatting, the weighting portion is omitted. All cards genrerated are "+rarity+", because this is a "+rarity+" pack. N can be an integer or a float, as explained above." : "");
+	}
+	
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 		// Gets the config and reads the cards, and runs the preinitialisation from the proxy
@@ -313,8 +323,16 @@ public class MineTradingCards {
 				+ "\nThis list applies even if \"can_drop\" is false."
 				);
 		
-		// === Logging ===
-		Logs.ENABLE_DEV_LOGS = config.getBoolean("devlog_enabled", CONFIG_CAT_LOGS, false, "Enable developer logs");
+		
+		// === Pack contents ===
+		PackItemRarity.COMMON_PACK_CONTENT = config.getStringList("common_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.COMMON_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Common", true));
+		PackItemRarity.UNCOMMON_PACK_CONTENT = config.getStringList("uncommon_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.UNCOMMON_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Uncommon", true));
+		PackItemRarity.RARE_PACK_CONTENT = config.getStringList("rare_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.RARE_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Rare", true));
+		PackItemRarity.ANCIENT_PACK_CONTENT = config.getStringList("ancient_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.ANCIENT_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Ancient", true));
+		PackItemRarity.LEGENDARY_PACK_CONTENT = config.getStringList("legendary_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemRarity.LEGENDARY_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Legendary", true));
+		PackItemStandard.STANDARD_PACK_CONTENT = config.getStringList("standard_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemStandard.STANDARD_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Standard", false));
+		PackItemEdition.EDITION_PACK_CONTENT = config.getStringList("edition_pack_contents", CONFIG_CAT_PACK_CONTENTS, PackItemStandard.STANDARD_PACK_CONTENT_DEFAULT, cardPackDistributionDescription("Edition", false));
+		
 		
 		// === Recipes ===
 		ENABLE_CARD_RECIPES = config.getBoolean("enable_card_recipes", CONFIG_CAT_RECIPES, true, "Enable recipes for crafting individual cards");
@@ -344,6 +362,9 @@ public class MineTradingCards {
 				);
 		CardMasterHomeHandler.SHOP_WEIGHT = config.getInt("card_shop_weight", CONFIG_CAT_VILLAGERS, 5, 0, 100, "Weighting for selection when villages generate. Farms and wood huts are 3, church is 20.");
 		CardMasterHomeHandler.SHOP_MAX_NUMBER = config.getInt("card_shop_max_number", CONFIG_CAT_VILLAGERS, 1, 0, 32, "Maximum number of card master shops that can spawn per village");
+
+		// === Logging ===
+		Logs.ENABLE_DEV_LOGS = config.getBoolean("devlog_enabled", CONFIG_CAT_LOGS, false, "Enable developer logs");
 		
 		// === Update Checker ===
 		ENABLE_UPDATE_CHECKER = config.getBoolean("enable_update_checker", CONFIG_CAT_UPDATES, true, "Displays a client-side chat message on login if there's an update available.");

--- a/src/main/java/com/is/mtc/card/CardItem.java
+++ b/src/main/java/com/is/mtc/card/CardItem.java
@@ -30,7 +30,9 @@ public class CardItem extends Item {
 	private static final int MAX_DESC_LENGTH = 42;
 
 	private int rarity;
-
+	
+	public static final int[] CARD_RARITY_ARRAY = new int[] {Rarity.COMMON, Rarity.UNCOMMON, Rarity.RARE, Rarity.ANCIENT, Rarity.LEGENDARY};
+	
 	public CardItem(int r) {
 		setUnlocalizedName(PREFIX + Rarity.toString(r).toLowerCase());
 		setTextureName(Reference.MODID + Reference.ITEM_CARD_GRAYSCALE);

--- a/src/main/java/com/is/mtc/pack/PackItemBase.java
+++ b/src/main/java/com/is/mtc/pack/PackItemBase.java
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 
 public class PackItemBase extends Item {
 
-	protected static final int RETRY = 5;
+	protected static final int RETRY = 50;
 
 	public PackItemBase() {
 		setCreativeTab(MineTradingCards.MODTAB);

--- a/src/main/java/com/is/mtc/pack/PackItemRarity.java
+++ b/src/main/java/com/is/mtc/pack/PackItemRarity.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import com.is.mtc.MineTradingCards;
+import com.is.mtc.card.CardItem;
 import com.is.mtc.data_manager.CardStructure;
 import com.is.mtc.data_manager.Databank;
 import com.is.mtc.root.Logs;
 import com.is.mtc.root.Rarity;
+import com.is.mtc.util.Functions;
 import com.is.mtc.util.Reference;
 
 import cpw.mods.fml.relauncher.Side;
@@ -16,50 +18,110 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-/*
- * Pack item drop informations
- * Drops up to 10 cards
- * cural: See table
- * Standard: 7, 2, 1 (Rare have a chance to be ancient or legendary)
- * Edition: Same as standard, but only from one edition
- */
-
 public class PackItemRarity extends PackItemBase {
-
-	private static final int[] cCount = new int[]{7, 2, 1, 0, 0};
-	private static final int[] uCount = new int[]{6, 3, 1, 0, 0};
-	private static final int[] rCount = new int[]{5, 3, 2, 0, 0};
-	private static final int[] aCount = new int[]{3, 3, 3, 1, 0};
-	private static final int[] lCount = new int[]{0, 0, 0, 0, 1};
-	private static final int[][] tCount = {cCount, uCount, rCount, aCount, lCount};
-
-	private static final String _str = "item_pack_";
+	
+	public static final String[] COMMON_PACK_CONTENT_DEFAULT = new String[] {
+			"7x",
+			"2x0:1:0:0:0",
+			"1x0:0:1:0:0",
+	};
+	public static final String[] UNCOMMON_PACK_CONTENT_DEFAULT = new String[] {
+			"6x1:0:0:0:0",
+			"3x",
+			"1x0:0:1:0:0",
+	};
+	public static final String[] RARE_PACK_CONTENT_DEFAULT = new String[] {
+			"5x1:0:0:0:0",
+			"3x0:1:0:0:0",
+			"2x",
+	};
+	public static final String[] ANCIENT_PACK_CONTENT_DEFAULT = new String[] {
+			"3x1:0:0:0:0",
+			"3x0:1:0:0:0",
+			"3x0:0:1:0:0",
+			"1x",
+	};
+	public static final String[] LEGENDARY_PACK_CONTENT_DEFAULT = new String[] {
+			"1x",
+	};
+	public static String[] COMMON_PACK_CONTENT = COMMON_PACK_CONTENT_DEFAULT;
+	public static String[] UNCOMMON_PACK_CONTENT = UNCOMMON_PACK_CONTENT_DEFAULT;
+	public static String[] RARE_PACK_CONTENT = RARE_PACK_CONTENT_DEFAULT;
+	public static String[] ANCIENT_PACK_CONTENT = ANCIENT_PACK_CONTENT_DEFAULT;
+	public static String[] LEGENDARY_PACK_CONTENT = LEGENDARY_PACK_CONTENT_DEFAULT;
+	
+	private static final String ITEM_PACK_UNLOC_PREFIX = "item_pack_";
 
 	private int rarity;
-
+	
 	public PackItemRarity(int r) {
-		setUnlocalizedName(_str + Rarity.toString(r).toLowerCase());
+		setUnlocalizedName(ITEM_PACK_UNLOC_PREFIX + Rarity.toString(r).toLowerCase());
 		setTextureName(Reference.MODID + Reference.ITEM_PACK_GRAYSCALE);
 
 		rarity = r;
 	}
-
+	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (world.isRemote) {return stack;} // Don't do this on the client side
+		
 		ArrayList<String> created;
-
-		if (world.isRemote)
-			return stack;
-
+		Random random = world.rand;
+		
+		// Figure out how many of each card rarity to create
+		
+		int[] card_set_to_create = new int[] {0,0,0,0,0}; // Set of cards that will come out of the pack
+		String[][] set_distribution_array = new String[][] {COMMON_PACK_CONTENT, UNCOMMON_PACK_CONTENT, RARE_PACK_CONTENT, ANCIENT_PACK_CONTENT, LEGENDARY_PACK_CONTENT};
+		
+		for (String entry : set_distribution_array[rarity])
+		{
+			try {
+				double[] card_weighted_dist = new double[] {0,0,0,0,0}; // Distribution used when a card is randomized
+				
+				// Split entry
+				String[] split_entry = entry.toLowerCase().trim().split("x");
+				
+				float count = MathHelper.clamp_float(Float.parseFloat(split_entry[0]), 0F, 64F);
+				int drop_count_characteristic = (int) count;
+				float drop_count_mantissa = count % 1;
+				
+				if (split_entry.length>1) {
+					String[] distribution_split = split_entry[1].split(":");
+					
+					for (int i=0; i<distribution_split.length; i++) {
+						card_weighted_dist[i]=Integer.parseInt(distribution_split[i].trim());
+					}
+				}
+				else {
+					card_weighted_dist[rarity]=1;
+				}
+				
+				// Repeat for the number of cards prescribed
+				for (int i=0; i<drop_count_characteristic + (random.nextFloat()<drop_count_mantissa ? 1 : 0); i++)
+				{
+					Object chosen_rarity = Functions.weightedRandom(CardItem.CARD_RARITY_ARRAY, card_weighted_dist, random);
+					
+					if (chosen_rarity!=null) {
+						card_set_to_create[(Integer)chosen_rarity]++;
+					}
+				}
+			}
+			catch (Exception e) {
+				Logs.errLog("Something went wrong parsing pack contents line: " + entry);
+			}
+		}
+		
+		// Actually create the cards
+		
 		created = new ArrayList<String>();
-		createCards(Rarity.COMMON, tCount[rarity][Rarity.COMMON], created, world.rand);
-		createCards(Rarity.UNCOMMON, tCount[rarity][Rarity.UNCOMMON], created, world.rand);
-		createCards(Rarity.RARE, tCount[rarity][Rarity.RARE], created, world.rand);
-		createCards(Rarity.ANCIENT, tCount[rarity][Rarity.ANCIENT], created, world.rand);
-		createCards(Rarity.LEGENDARY, tCount[rarity][Rarity.LEGENDARY], created, world.rand);
-
+		
+		for (int rarity : CardItem.CARD_RARITY_ARRAY) {
+			createCards(rarity, card_set_to_create[rarity], created, world.rand);
+		}
+		
 		if (created.size() > 0) {
 			for (String cdwd : created) {
 				spawnCard(player, world, cdwd);
@@ -69,7 +131,7 @@ public class PackItemRarity extends PackItemBase {
 			Logs.chatMessage(player, "Zero cards were registered, thus zero cards were generated");
 			Logs.errLog("Zero cards were registered, thus zero cards can be generated");
 		}
-
+		
 		return stack;
 	}
 
@@ -79,10 +141,10 @@ public class PackItemRarity extends PackItemBase {
 		for (int x = 0; x < count; ++x) { // Generate x cards
 			CardStructure cStruct = null;
 
-			for (int y = 0; y < RETRY; ++y) { // Retry x times until...
+			for (int y = 0; y < RETRY; ++y) { // Retry y times until...
 				cStruct = Databank.generateACard(cardRarity, random);
-
-				if (cStruct != null && !created.contains(cStruct.getCDWD())) { // ... cards was not already created. Duplicate prevention
+				
+				if (cStruct != null && !created.contains(cStruct.getCDWD())) { // ... card was not already created. Duplicate prevention
 					created.add(cStruct.getCDWD());
 					break;
 				}

--- a/src/main/java/com/is/mtc/pack/PackItemStandard.java
+++ b/src/main/java/com/is/mtc/pack/PackItemStandard.java
@@ -1,10 +1,12 @@
 package com.is.mtc.pack;
 
 import java.util.ArrayList;
+import java.util.Random;
 
 import com.is.mtc.MineTradingCards;
+import com.is.mtc.card.CardItem;
 import com.is.mtc.root.Logs;
-import com.is.mtc.root.Rarity;
+import com.is.mtc.util.Functions;
 import com.is.mtc.util.Reference;
 
 import cpw.mods.fml.relauncher.Side;
@@ -13,14 +15,18 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
 public class PackItemStandard extends PackItemBase {
-
-	private static final int[] cCount = {7, 2, 1};
-	private static final int[] rWeight = {25, 29, 30};
-	private static final int rtWeight = rWeight[2];
-
+	
+	public static final String[] STANDARD_PACK_CONTENT_DEFAULT = new String[] {
+			"7x1:0:0:0:0",
+			"2x0:1:0:0:0",
+			"1x0:0:25:4:1",
+	};
+	public static String[] STANDARD_PACK_CONTENT = STANDARD_PACK_CONTENT_DEFAULT;
+	
 	public PackItemStandard() {
 		setUnlocalizedName("item_pack_standard");
 		setTextureName(Reference.MODID + Reference.ITEM_PACK_GRAYSCALE);
@@ -28,27 +34,56 @@ public class PackItemStandard extends PackItemBase {
 
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (world.isRemote) {return stack;} // Don't do this on the client side
+
 		ArrayList<String> created;
+		Random random = world.rand;
 		
-		if (world.isRemote) {
-			return stack;
+		// Figure out how many of each card rarity to create
+		
+		int[] card_set_to_create = new int[] {0,0,0,0,0}; // Set of cards that will come out of the pack
+		
+		for (String entry : STANDARD_PACK_CONTENT)
+		{
+			try {
+				double[] card_weighted_dist = new double[] {0,0,0,0,0}; // Distribution used when a card is randomized
+				
+				// Split entry
+				String[] split_entry = entry.toLowerCase().trim().split("x");
+				
+				float count = MathHelper.clamp_float(Float.parseFloat(split_entry[0]), 0F, 64F);
+				int drop_count_characteristic = (int) count;
+				float drop_count_mantissa = count % 1;
+				
+				String[] distribution_split = split_entry[1].split(":");
+				
+				for (int i=0; i<distribution_split.length; i++) {
+					card_weighted_dist[i]=Integer.parseInt(distribution_split[i].trim());
+				}
+				
+				// Repeat for the number of cards prescribed
+				for (int i=0; i<drop_count_characteristic + (random.nextFloat()<drop_count_mantissa ? 1 : 0); i++)
+				{
+					Object chosen_rarity = Functions.weightedRandom(CardItem.CARD_RARITY_ARRAY, card_weighted_dist, random);
+					
+					if (chosen_rarity!=null) {
+						card_set_to_create[(Integer)chosen_rarity]++;
+					}
+				}
+			}
+			catch (Exception e) {
+				Logs.errLog("Something went wrong parsing standard_pack_contents line: " + entry);
+			}
 		}
 
+		// Actually create the cards
+		
 		created = new ArrayList<String>();
-		createCards(Rarity.COMMON, cCount[Rarity.COMMON], created, world.rand);
-		createCards(Rarity.UNCOMMON, cCount[Rarity.UNCOMMON], created, world.rand);
-
-		int i = world.rand.nextInt(rtWeight);
-		if (i < rWeight[0]) {
-			createCards(Rarity.RARE, cCount[Rarity.RARE], created, world.rand);
+		
+		for (int rarity : CardItem.CARD_RARITY_ARRAY) {
+			createCards(rarity, card_set_to_create[rarity], created, world.rand);
 		}
-		else if (i < rWeight[1]) {
-			createCards(Rarity.ANCIENT, cCount[Rarity.RARE], created, world.rand);
-		}
-		else if (i < rWeight[2]) {
-			createCards(Rarity.LEGENDARY, cCount[Rarity.RARE], created, world.rand);
-		}
-
+		
 		if (created.size() > 0) {
 			for (String cdwd : created) {
 				spawnCard(player, world, cdwd);
@@ -58,7 +93,7 @@ public class PackItemStandard extends PackItemBase {
 			Logs.chatMessage(player, "Zero cards were registered, thus zero cards were generated");
 			Logs.errLog("Zero cards were registered, thus zero cards can be generated");
 		}
-
+		
 		return stack;
 	}
 	


### PR DESCRIPTION
Here I've added config options that lets users specify how many of which cards can appear in which pack types. Since there is a precedence for a pack type that has at least one randomized card type in it (i.e. Standard), I have added the flexibility for a weighted card choice.

All default values mirror the already-existing pack content values.

I've also increased `PackItemBase.RETRY` to 50 because Java is pretty fast and can probably get away with re-rolling up to 50 times to search for a non-duplicate.